### PR TITLE
Fixes #5 - Adds reference to netstandard in MSBuildWrapper

### DIFF
--- a/src/MSBuildWrapper/MSBuildWrapper.csproj
+++ b/src/MSBuildWrapper/MSBuildWrapper.csproj
@@ -34,6 +34,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="netstandard" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />


### PR DESCRIPTION
Although the base development environment for the project doesn't need this reference (Visual Studio Community 2017, .NET Desktop Development workload + .NET Framework 4.6.2 SDK and Targeting Pack), issue #5 reports not being able to compile the solution.

Apparently, because we're pulling MSBuild 15 from NuGet, we're also pulling a lot of `.dll` including `System.Collections.Immutable 1.5.0` which references `netstandard` internally but doesn't get pulled via NuGet (dotnet/standard#534).

From this other issue (dotnet/standard#545), it looks like we'll be able to remove this reference when we upgrade to MSBuild 16 and .NET Framework 4.7.2 (part of #4).